### PR TITLE
refactor: remove ProcessPoolExecutor to resolve pickle serialization …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,5 @@ claude-flow.bat
 claude-flow.ps1
 hive-mind-prompt-*.txt
 .claude-flow/
+.bmad-core/
+.trae/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # CLAUDE.md
-
+- 使用中文内容
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## 核心原则


### PR DESCRIPTION
…issues (#1)

- Remove ProcessPoolExecutor import and support
- Update fan_out_to, fan_out_in methods to only support ThreadPoolExecutor
- Add validation to reject 'process' executor with clear error message
- Update parallel_fan_out function documentation
- Modify test_fan_primitives.py to test executor validation instead of comparison
- All 69 existing tests pass, maintaining backward compatibility for ThreadPoolExecutor

Breaking change: ProcessPoolExecutor is no longer supported
Benefits: Eliminates pickle serialization complexity, simplifies codebase architecture