### PR TITLE
docs: 添加Claude Code开发指导原则

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,3 +168,76 @@ pdm run bandit -r src/
 - **执行跟踪**: 记录每个节点的执行时间和状态
 - **并行可视化**: 使用ParallelResult分析并发执行效果
 - **依赖注入诊断**: 验证容器配置和服务注册状态
+
+---
+
+## Claude Code 开发指导原则
+
+> Think carefully and implement the most concise solution that changes as little code as possible.
+
+## USE SUB-AGENTS FOR CONTEXT OPTIMIZATION
+
+### 1. Always use the file-analyzer sub-agent when asked to read files.
+The file-analyzer agent is an expert in extracting and summarizing critical information from files, particularly log files and verbose outputs. It provides concise, actionable summaries that preserve essential information while dramatically reducing context usage.
+
+### 2. Always use the code-analyzer sub-agent when asked to search code, analyze code, research bugs, or trace logic flow.
+
+The code-analyzer agent is an expert in code analysis, logic tracing, and vulnerability detection. It provides concise, actionable summaries that preserve essential information while dramatically reducing context usage.
+
+### 3. Always use the test-runner sub-agent to run tests and analyze the test results.
+
+Using the test-runner agent ensures:
+
+- Full test output is captured for debugging
+- Main conversation stays clean and focused
+- Context usage is optimized
+- All issues are properly surfaced
+- No approval dialogs interrupt the workflow
+
+## Philosophy
+
+### Error Handling
+
+- **Fail fast** for critical configuration (missing text model)
+- **Log and continue** for optional features (extraction model)
+- **Graceful degradation** when external services unavailable
+- **User-friendly messages** through resilience layer
+
+### Testing
+
+- Always use the test-runner agent to execute tests.
+- Do not use mock services for anything ever.
+- Do not move on to the next test until the current test is complete.
+- If the test fails, consider checking if the test is structured correctly before deciding we need to refactor the codebase.
+- Tests to be verbose so we can use them for debugging.
+
+## Tone and Behavior
+
+- Criticism is welcome. Please tell me when I am wrong or mistaken, or even when you think I might be wrong or mistaken.
+- Please tell me if there is a better approach than the one I am taking.
+- Please tell me if there is a relevant standard or convention that I appear to be unaware of.
+- Be skeptical.
+- Be concise.
+- Short summaries are OK, but don't give an extended breakdown unless we are working through the details of a plan.
+- Do not flatter, and do not give compliments unless I am specifically asking for your judgement.
+- Occasional pleasantries are fine.
+- Feel free to ask many questions. If you are in doubt of my intent, don't guess. Ask.
+
+## ABSOLUTE RULES:
+
+- NO PARTIAL IMPLEMENTATION
+- NO SIMPLIFICATION : no "//This is simplified stuff for now, complete implementation would blablabla"
+- NO CODE DUPLICATION : check existing codebase to reuse functions and constants Read files before writing new functions. Use common sense function name to find them easily.
+- NO DEAD CODE : either use or delete from codebase completely
+- IMPLEMENT TEST FOR EVERY FUNCTIONS
+- NO CHEATER TESTS : test must be accurate, reflect real usage and be designed to reveal flaws. No useless tests! Design tests to be verbose so we can use them for debuging.
+- NO INCONSISTENT NAMING - read existing codebase naming patterns.
+- NO OVER-ENGINEERING - Don't add unnecessary abstractions, factory patterns, or middleware when simple functions would work. Don't think "enterprise" when you need "working"
+- NO MIXED CONCERNS - Don't put validation logic inside API handlers, database queries inside UI components, etc. instead of proper separation
+- NO RESOURCE LEAKS - Don't forget to close database connections, clear timeouts, remove event listeners, or clean up file handles
+
+# important-instruction-reminders
+Do what has been asked; nothing more, nothing less.
+NEVER create files unless they're absolutely necessary for achieving your goal.
+ALWAYS prefer editing an existing file to creating a new one.
+NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.


### PR DESCRIPTION
## Summary
为Claude Code协作添加开发指导原则，提升开发效率和代码质量。

- 添加子代理使用指导以优化上下文使用
- 明确错误处理和测试哲学
- 制定开发行为准则和绝对规则
- 为Claude Code协作提供清晰的框架

## Key Changes
- **子代理优化**: file-analyzer、code-analyzer、test-runner的使用指南
- **错误处理哲学**: fail fast、graceful degradation等原则
- **测试准则**: 禁用mock、详细测试、准确反映真实使用
- **行为规范**: 简洁、批判性思维、询问优于猜测
- **开发绝对规则**: 11条严格的开发规范

## Test plan
- [x] 文档格式和内容检查
- [x] 与现有CLAUDE.md结构的兼容性
- [x] 开发指导原则的完整性验证

🤖 Generated with [Claude Code](https://claude.ai/code)