### PR TITLE
Fix node retry gating and direct-call overloads

### DIFF
--- a/src/streamlet/node.py
+++ b/src/streamlet/node.py
@@ -276,6 +276,21 @@ def node_decorator(func: Callable[..., Any]) -> Node: ...
 
 @overload
 def node_decorator(
+    func: Callable[..., Any],
+    *,
+    retry_count: int = 3,
+    name: str | None = None,
+    timeout: float | None = None,
+    retry_delay: float = 1.0,
+    exception_types: tuple[type[Exception], ...] = (Exception,),
+    backoff_factor: float = 1.0,
+    max_delay: float = 60.0,
+    enable_retry: bool = False,
+) -> Node: ...
+
+
+@overload
+def node_decorator(
     func: None = None,
     *,
     retry_count: int = 3,
@@ -302,8 +317,12 @@ def node_decorator(
     enable_retry: bool = False,
 ) -> Node | Callable[[Callable[..., Any]], Node]:
     """保持现有签名不变。"""
-    config = RetryConfig(
-        retry_count, retry_delay, exception_types, backoff_factor, max_delay
+    config = (
+        RetryConfig(
+            retry_count, retry_delay, exception_types, backoff_factor, max_delay
+        )
+        if enable_retry
+        else None
     )
     timeout = _validate_timeout(timeout)
 
@@ -319,7 +338,7 @@ def node_decorator(
                 node_name=node_name,
             ),
         ]
-        if enable_retry:
+        if config is not None:
             decorators.append(retry_decorator(config=config, node_name=node_name))
         if _has_di_marker(f):
             decorators.append(_di_inject)

--- a/tests/test_node_decorator.py
+++ b/tests/test_node_decorator.py
@@ -41,6 +41,40 @@ class TestNodeDecoratorCallModes:
 
         assert func.name == "custom_name"
 
+    def test_node_with_direct_func_and_explicit_name(self):
+        def func(x: int) -> int:
+            return x * 2
+
+        decorated = node(func, name="custom_name")
+
+        assert isinstance(decorated, Node)
+        assert decorated.name == "custom_name"
+        assert decorated(5) == 10
+
+    def test_node_with_direct_func_and_retry_options(self):
+        call_count = 0
+
+        class TempError(Exception):
+            retryable = True
+
+        def func(x: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise TempError("retry")
+            return x * 2
+
+        decorated = node(
+            func,
+            retry_count=1,
+            retry_delay=0,
+            exception_types=(TempError,),
+            enable_retry=True,
+        )
+
+        assert decorated(5) == 10
+        assert call_count == 2
+
     def test_plain_node_does_not_emit_di_wiring_warning(self):
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -261,12 +261,12 @@ class TestNodeWithRetry:
         result = stable_node(5)
         assert result == 10
 
-    def test_node_validates_retry_arguments_when_retry_disabled(self):
-        with pytest.raises(ValueError, match="retry_count"):
+    def test_node_ignores_retry_arguments_when_retry_disabled(self):
+        @node(retry_count=-1, retry_delay=-0.1, enable_retry=False)
+        def stable_node(x: int) -> int:
+            return x * 2
 
-            @node(retry_count=-1, enable_retry=False)
-            def stable_node(x: int) -> int:
-                return x * 2
+        assert stable_node(5) == 10
 
     @pytest.mark.asyncio
     async def test_async_node_with_retry(self):


### PR DESCRIPTION
### Motivation
- Prevent `@node` from validating retry parameters when retry is disabled so decoration of non-retrying nodes cannot fail due to invalid retry args. 
- Ensure the `node(func, ...)` direct-call typing overload matches the runtime-supported keyword surface so static checkers accept the common direct-call patterns.
- Have the changes reviewed automatically to catch coverage/typing gaps before finalizing.

### Description
- Gate `RetryConfig` construction behind `enable_retry` so `RetryConfig` is only created when retry is enabled and the retry decorator is only attached when config is present. 
- Add a direct-function overload for `node_decorator(func, *, ...) -> Node` that includes the full set of keyword-only parameters (`retry_count`, `name`, `timeout`, `retry_delay`, `exception_types`, `backoff_factor`, `max_delay`, `enable_retry`) to mirror runtime behavior. 
- Add runtime regression tests: `test_node_with_direct_func_and_explicit_name` to cover `node(func, name=...)`, `test_node_with_direct_func_and_retry_options` to cover `node(func, enable_retry=True, ...)`, and update `test_node_ignores_retry_arguments_when_retry_disabled` to assert invalid retry args are ignored when `enable_retry=False`. 
- Ran an automated subagent review (Gibbs) to validate the diff and suggested adding a static type-check snippet as optional extra coverage; no blocking issues found.

### Testing
- Ran linters with `pdm run ruff check src/ tests/` and formatting with `pdm run ruff format` and no issues were reported. 
- Ran static type checks with `pdm run mypy src/streamlet/` and the relevant checks passed in this environment. 
- Ran the full test suite with `pdm run pytest` and all tests passed (`260 passed`). 
- Also ran targeted tests for the new/updated cases (`tests/test_node_decorator.py` and `tests/test_retry.py`) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4731708e948332ad8189c6d1a74cd0)