### PR TITLE
Validate documentation examples and API contracts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         pdm run ruff check src/ tests/
         pdm run ruff format --check src/ tests/
-        pdm run mypy src/streamlet/
+        pdm run mypy src/streamlet/ tests/typecheck/
         pdm run bandit -r src/
 
     - name: Run tests with pytest

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ def double(x: int) -> int:
 def add_ten(x: int) -> int:
     return x + 10
 
-result = double.then(add_ten)(5)  # 20
+assert double.then(add_ten)(5) == 20
 ```
 
 ## 核心 API
@@ -60,7 +60,8 @@ fan-out 的失败模型只包装普通业务异常：target 抛出的 `Exception
 `ParallelResult(success=False, error=...)`；这种普通 target 失败不阻断其他
 target。
 `asyncio.CancelledError`、`KeyboardInterrupt`、`SystemExit` 等取消或进程级
-中断不会被包装，会向外传播并中断整个 fan-out。
+中断不会被包装，而是向调用方传播，因此本次 fan-out 不返回结果字典。传播不
+保证取消已经开始执行的 sibling target；这些 target 仍可能继续运行或完成。
 
 `repeat` 默认使用 `RepeatInputMode.PREVIOUS_RESULT`：第 1 轮执行
 `node(*args, **kwargs)`，之后把每轮成功返回值作为下一轮的单个位置参数。
@@ -82,12 +83,21 @@ def step(value: int, factor: int = 1) -> CallArgs:
 
 assert step.repeat(3)(2, factor=10) == call_args(2000, factor=10)
 
-@node
-def collect(source: str, limit: int = 10) -> list[str]:
-    return fetch_batch(source, limit=limit)
+fetch_calls: list[tuple[str, int]] = []
 
-flow = collect.repeat(3, input_mode=RepeatInputMode.SAME_INPUT)
-results = flow("orders", limit=50)
+@node
+def fetch(source: str, limit: int = 10) -> list[str]:
+    fetch_calls.append((source, limit))
+    return [f"{source}:{index}" for index in range(limit)]
+
+flow = fetch.repeat(
+    3,
+    stop_on_error=True,
+    input_mode=RepeatInputMode.SAME_INPUT,
+)
+results = flow("orders", limit=2)
+assert results == ["orders:0", "orders:1"]
+assert fetch_calls == [("orders", 2)] * 3
 ```
 
 `@node` 内置 Pydantic 输入和返回值校验。返回值校验支持
@@ -124,7 +134,11 @@ pipeline = fetch_data.then(validate).then(enrich)
 
 async def main():
     result = await pipeline("db")
-    print(result)  # {"value": 100, "source": "db", "doubled": 200}
+    assert result == {
+        "value": 100,
+        "source": "db",
+        "doubled": 200,
+    }
 
 asyncio.run(main())
 ```
@@ -153,7 +167,8 @@ def aggregate(results: dict) -> dict:
 
 workflow = source.fan_out_to([multiply, add_ten], executor="thread").fan_in(aggregate)
 result = workflow(5)
-print(result)  # {"total": 25, "results": [10, 15]}
+assert result["total"] == 25
+assert sorted(result["results"]) == [10, 15]
 ```
 
 注意：`fan_out_to([multiply, add_ten]).then(next_node)` 会把
@@ -164,6 +179,8 @@ source 返回普通值时，所有 target 接收同一个单参数；需要为�
 传递不同 kwargs 时，返回显式的 `fan_out_args`：
 
 ```python
+from streamlet import fan_out_args, node
+
 @node
 def route(user_id: str):
     return fan_out_args(
@@ -171,7 +188,23 @@ def route(user_id: str):
         {"user_id": user_id, "include_archived": False},
     )
 
+@node
+def fetch_orders(user_id: str, limit: int) -> list[str]:
+    return [f"order:{user_id}:{index}" for index in range(limit)]
+
+@node
+def fetch_profile(user_id: str, include_archived: bool) -> dict:
+    return {"user_id": user_id, "include_archived": include_archived}
+
 flow = route.fan_out_to([fetch_orders, fetch_profile])
+results = flow("u-1")
+assert results["fetch_orders"].result == [
+    f"order:u-1:{index}" for index in range(10)
+]
+assert results["fetch_profile"].result == {
+    "user_id": "u-1",
+    "include_archived": False,
+}
 ```
 
 ### 条件流：分支路由 + 依赖注入
@@ -198,7 +231,10 @@ container.wire(modules=[__name__])
 container.context()["score"] = 75
 
 flow = evaluate.branch_on({"pass": handle_pass, "fail": handle_fail})
-print(flow({"score": 75}))  # {"result": "pass", "score": 75}
+assert flow({"score": 80}) == {
+    "result": "pass",
+    "score": 75,
+}
 ```
 
 `branch_on` 的语义是：条件节点接收调用输入并返回路由键，选中的分支节点
@@ -217,20 +253,31 @@ class StrictFlowContext(BaseFlowContext):
     context = ContextVarProvider(dict, copy_policy="strict")
 ```
 
-`copy_policy="strict"` 不会递归深拷贝 context；它会在 fan-out 隔离时检测并拒绝
-会被浅拷贝共享的可变值，让共享状态风险尽早暴露。直接的 `list` / `dict` /
-`set` 会被拒绝，藏在 `tuple` / `frozenset` 等不可变容器里的可变值也会被拒绝，
-例如 `{"items": ("header", [])}`。
+`copy_policy="strict"` 不会递归深拷贝 context；它会在 fan-out 或同步 `timeout`
+跨执行上下文传播时，拒绝被浅拷贝共享的可变值，让共享状态风险尽早暴露。直接的
+`list` / `dict` / `set` 会被拒绝，藏在 `tuple` / `frozenset` 等不可变容器里的
+可变值也会被拒绝，例如 `{"items": ("header", [])}`。
 
 ### 重试机制
 
 ```python
 from streamlet import node
 
-@node(retry_count=3, retry_delay=0.5, backoff_factor=2.0, enable_retry=True)
+attempts = 0
+
+def call_external_api(x: int) -> int:
+    global attempts
+    attempts += 1
+    if attempts == 1:
+        raise ConnectionError("temporary failure")
+    return x * 2
+
+@node(retry_count=3, retry_delay=0, enable_retry=True)
 def external_call(x: int) -> int:
-    # 失败时自动重试，延迟按 0.5s → 1.0s → 2.0s 指数增长
     return call_external_api(x)
+
+assert external_call(5) == 10
+assert attempts == 2
 ```
 
 ## 开发环境
@@ -244,7 +291,7 @@ pdm install
 pdm run pytest                                   # 运行测试
 pdm run pytest --cov=src/streamlet              # 覆盖率
 pdm run ruff check src/ tests/                   # 代码检查
-pdm run mypy src/streamlet/                     # 类型检查
+pdm run mypy src/streamlet/ tests/typecheck/    # 类型检查
 ```
 
 ## 技术栈

--- a/docs/API参考.md
+++ b/docs/API参考.md
@@ -2,23 +2,26 @@
 
 ## @node 装饰器
 
-```python
-@node(
+```signature
+node(
+    func: Callable[..., Any] | None = None,
+    *,
+    retry_count: int = 3,
     name: str | None = None,
     timeout: float | None = None,
-    retry_count: int = 3,
     retry_delay: float = 1.0,
-    exception_types: tuple = (Exception,),
+    exception_types: tuple[type[Exception], ...] = (Exception,),
     backoff_factor: float = 1.0,
     max_delay: float = 60.0,
     enable_retry: bool = False,
-)
+) -> Node | Callable[[Callable[..., Any]], Node]
 ```
 
 将函数转为 `Node` 实例，内置 pydantic 类型校验、按需依赖注入和可选重试。
 
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
+| `func` | `Callable[..., Any] \| None` | `None` | 待包装函数；省略时返回装饰器 |
 | `name` | `str \| None` | 函数名 | 节点标识 |
 | `timeout` | `float \| None` | `None` | 单次节点调用超时时间（秒） |
 | `retry_count` | `int` | `3` | 最大重试次数 |
@@ -28,7 +31,8 @@
 | `max_delay` | `float` | `60.0` | 重试延迟上限（秒） |
 | `enable_retry` | `bool` | `False` | 是否启用重试 |
 
-支持两种调用方式：`@node`（无参数）和 `@node(name="n")`（带参数）。
+作为装饰器支持 `@node`（无参数）和 `@node(name="n")`（带参数）；也可直接
+调用 `node(func)` 或 `node(func, name="n", ...)`，并立即返回 `Node`。
 `timeout` 必须为正数；节点调用超过该时间会抛出 `NodeTimeoutException`，
 异常包含 `node_name` 和 `timeout_seconds`。同步函数通过 `func-timeout` 执行，
 异步函数通过 `asyncio.wait_for` 执行。启用重试时，`timeout` 是整次节点调用的
@@ -42,10 +46,12 @@ fan-out 线程池或其他用户线程中，传播的是该调用线程当时的
 context 值只浅拷贝顶层字典，非 `dict` 对象按原引用传播。对象是否可跨线程使用
 由用户保证；线程绑定资源（例如部分 DB session、request scoped 对象、依赖当前
 event loop 的 client）不应直接放入同步 timeout 节点的 context。
+同步 timeout 的上下文传播同样会执行 `copy_policy="strict"` 校验，避免工作线程
+共享嵌套可变状态。
 
-重试只在 `enable_retry=True` 时执行；但 `retry_count`、`retry_delay`、
-`exception_types`、`backoff_factor` 和 `max_delay` 会在装饰器入口统一校验，
-即使未启用重试也会对无效参数早失败。
+重试配置只在 `enable_retry=True` 时构造、校验并执行。未启用重试时，
+`retry_count`、`retry_delay`、`exception_types`、`backoff_factor` 和
+`max_delay` 会被忽略；`timeout` 仍始终校验。
 
 输入校验失败抛出 `ValidationInputException`，返回值校验失败抛出
 `ValidationOutputException`。返回值校验基于函数的返回类型注解，支持
@@ -53,10 +59,12 @@ event loop 的 client）不应直接放入同步 timeout 节点的 context。
 `Annotated[...]` 元数据给 Pydantic 处理。因此可以在返回类型里使用
 Pydantic 模型和 `Field` 约束：
 
+下面用返回 `Any` 的 helper 模拟外部未校验数据，类型转换由节点的输出校验完成。
+
 ```python
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field
 from streamlet import node
@@ -67,14 +75,26 @@ class User(BaseModel):
     age: int
 
 
-@node
-def create_user() -> User:
+def load_user_payload() -> Any:
     return {"name": "Alice", "age": "30"}
 
 
 @node
+def create_user() -> User:
+    return load_user_payload()
+
+
+def load_score() -> Any:
+    return "100"
+
+
+@node
 def positive_score() -> Annotated[int, Field(gt=0)]:
-    return 100
+    return load_score()
+
+
+assert create_user() == User(name="Alice", age=30)
+assert positive_score() == 100
 ```
 
 依赖注入在函数签名包含 `Provide[...]` / `Provider[...]` 默认值或
@@ -82,11 +102,25 @@ def positive_score() -> Annotated[int, Field(gt=0)]:
 
 ## Node 类
 
-### `then(next_node: Node) -> Node`
+### `then(other: Node) -> Node`
+
+```signature
+then(
+    other: Node,
+) -> Node
+```
 
 顺序连接。前一个节点的输出作为后一个节点的输入。
 
-### `fan_out_to(nodes: list[Node], executor: str = "thread", max_workers: int = None) -> Node`
+### `fan_out_to(nodes: list[Node], executor: str = "thread", max_workers: int | None = None) -> Node`
+
+```signature
+fan_out_to(
+    nodes: list[Node],
+    executor: str = "thread",
+    max_workers: int | None = None,
+) -> Node
+```
 
 并行扇出。source 执行后，每个 target 并行执行。返回 `dict[str, ParallelResult]`。
 如果后面继续调用 `.then(next_node)`，`next_node` 接收的也是这个原始结果字典，
@@ -100,7 +134,8 @@ def positive_score() -> Annotated[int, Field(gt=0)]:
 target 抛出的普通 `Exception` 会被包装为 `ParallelResult(success=False)`，
 并保留 `error` 与 `error_traceback`；这种普通 target 失败不阻断其他 target。
 取消或进程级中断不会被包装：`asyncio.CancelledError`、`KeyboardInterrupt`、
-`SystemExit` 会向外传播并中断整个 fan-out。
+`SystemExit` 会向调用方传播，因此本次 fan-out 不返回结果字典。传播不保证取消
+已经开始执行的 sibling target；这些 target 仍可能继续运行或完成。
 
 `executor` 取值：
 - `"thread"` — 线程池（默认），更适合 I/O 密集或阻塞型任务
@@ -129,21 +164,58 @@ def source(user_id: str):
         {"user_id": user_id, "include_archived": False},
     )
 
+@node
+def fetch_orders(user_id: str, limit: int) -> list[str]:
+    return [f"order:{user_id}:{index}" for index in range(limit)]
+
+@node
+def fetch_profile(user_id: str, include_archived: bool) -> dict:
+    return {"user_id": user_id, "include_archived": include_archived}
+
 flow = source.fan_out_to([fetch_orders, fetch_profile])
+results = flow("u-1")
+assert results["fetch_orders"].result == [
+    f"order:u-1:{index}" for index in range(10)
+]
+assert results["fetch_profile"].result == {
+    "user_id": "u-1",
+    "include_archived": False,
+}
 ```
 
 ### `fan_in(aggregator: Node) -> Node`
+
+```signature
+fan_in(
+    aggregator: Node,
+) -> Node
+```
 
 聚合并行结果。aggregator 接收 `dict[str, ParallelResult]` 参数。
 
 `fan_in` 是 fan-out 后回到普通业务链的显式入口：aggregator 负责检查
 `ParallelResult.success`、处理失败分支，并返回下游 `.then(...)` 真正需要的业务值。
 
-### `fan_out_in(targets: list[Node], aggregator: Node, executor: str = "thread", max_workers: int = None) -> Node`
+### `fan_out_in(targets: list[Node], aggregator: Node, executor: str = "thread", max_workers: int | None = None) -> Node`
+
+```signature
+fan_out_in(
+    targets: list[Node],
+    aggregator: Node,
+    executor: str = "thread",
+    max_workers: int | None = None,
+) -> Node
+```
 
 `fan_out_to` + `fan_in` 组合，一步完成。
 
 ### `branch_on(conditions: dict[Any, Node]) -> Node`
+
+```signature
+branch_on(
+    conditions: dict[Any, Node],
+) -> Node
+```
 
 条件分支。条件节点返回值作为路由键，匹配对应分支节点执行。
 
@@ -152,6 +224,15 @@ flow = source.fan_out_to([fetch_orders, fetch_profile])
 可通过依赖注入读取 `BaseFlowContext.context`。
 
 ### `repeat(times: int, stop_on_error: bool = False, *, input_mode: RepeatInputMode = RepeatInputMode.PREVIOUS_RESULT) -> Node`
+
+```signature
+repeat(
+    times: int,
+    stop_on_error: bool = False,
+    *,
+    input_mode: RepeatInputMode = RepeatInputMode.PREVIOUS_RESULT,
+) -> Node
+```
 
 重复执行节点，并返回最后一次成功执行的结果。
 
@@ -177,12 +258,21 @@ def step(value: int, factor: int = 1) -> CallArgs:
 
 assert step.repeat(3)(2, factor=10) == call_args(2000, factor=10)
 
+load_calls: list[tuple[str, int]] = []
+
 @node
 def load(source: str, limit: int = 10) -> list[str]:
-    return fetch_batch(source, limit=limit)
+    load_calls.append((source, limit))
+    return [f"{source}:{index}" for index in range(limit)]
 
-flow = load.repeat(3, input_mode=RepeatInputMode.SAME_INPUT)
-result = flow("orders", limit=50)
+flow = load.repeat(
+    3,
+    stop_on_error=True,
+    input_mode=RepeatInputMode.SAME_INPUT,
+)
+result = flow("orders", limit=2)
+assert result == ["orders:0", "orders:1"]
+assert load_calls == [("orders", 2)] * 3
 ```
 
 `call_args(*args, **kwargs)` 会创建显式的下一轮调用参数。`PREVIOUS_RESULT` 不会自动展开普通 `tuple` 或 `dict`；这些类型会被视为业务返回值，作为一个位置参数传入下一轮。
@@ -193,7 +283,7 @@ result = flow("orders", limit=50)
 
 ## RetryConfig
 
-```python
+```signature
 RetryConfig(
     retry_count: int = 3,
     retry_delay: float = 1.0,
@@ -213,8 +303,7 @@ RetryConfig(
 
 ## ParallelResult
 
-```python
-@dataclass
+```signature
 class ParallelResult:
     node_name: str
     success: bool
@@ -227,13 +316,14 @@ class ParallelResult:
 `fan_out_to` 返回 `dict[str, ParallelResult]`，键为节点名（重复时自动加后缀 `[n]`）。
 `ParallelResult(success=False)` 只表示 target 的普通业务异常被包装；取消、
 `KeyboardInterrupt`、`SystemExit` 等 `BaseException` 路径会直接传播，不会生成
-`ParallelResult`。
+`ParallelResult`，fan-out 也不会返回结果字典。已经开始执行的 sibling target
+不保证被取消，仍可能继续运行或完成。
 
 ## BaseFlowContext
 
 依赖注入容器，继承 `dependency-injector` 的 `DeclarativeContainer`。
 
-```python
+```python compile-only
 container = BaseFlowContext()
 container.wire(modules=[__name__])
 ```
@@ -255,6 +345,8 @@ def my_node(context: dict = Provide[BaseFlowContext.context]) -> dict:
     return {"data": context["key"]}
 
 container.wire(modules=[__name__])  # 必须在 @node 定义之后调用
+container.context()["key"] = "value"
+assert my_node() == {"data": "value"}
 ```
 
 fan-out 分支复制父上下文时，默认只浅拷贝顶层 `dict`。这会隔离顶层 key 的新增、
@@ -263,7 +355,7 @@ fan-out 分支复制父上下文时，默认只浅拷贝顶层 `dict`。这会�
 
 ## ContextVarProvider
 
-```python
+```signature
 ContextVarProvider(
     default_factory: Callable[[], Any] = dict,
     copy_policy: str = "shallow",
@@ -274,14 +366,14 @@ ContextVarProvider(
 默认使用 `ContextVarProvider(dict)`。
 
 `copy_policy` 取值：
-- `"shallow"` — 默认策略；fan-out 隔离时只浅拷贝顶层 `dict`
-- `"strict"` — fan-out 隔离时拒绝嵌套可变值和非 `dict` 可变 context 值，不做
-  递归深拷贝
+- `"shallow"` — 默认策略；跨执行上下文传播时只浅拷贝顶层 `dict`
+- `"strict"` — fan-out 或同步 timeout 传播时拒绝嵌套可变值和非 `dict` 可变
+  context 值，不做递归深拷贝
 
-`strict` 的目标是提前暴露浅拷贝无法隔离的共享状态风险，而不是自动复制这些
-对象。直接作为 value 的 `list` / `dict` / `set` 会被拒绝，包含在 `tuple` /
-`frozenset` 等不可变容器里的可变值也会被拒绝，例如
-`{"items": ("header", [])}`。
+`strict` 是跨执行上下文传播的风险门禁，目标是提前暴露浅拷贝无法隔离的共享状态
+风险，而不是自动复制这些对象。直接作为 value 的 `list` / `dict` / `set` 会被
+拒绝，包含在 `tuple` / `frozenset` 等不可变容器里的可变值也会被拒绝，例如
+`{"items": ("header", [])}`。普通节点调用不会触发这项校验。
 
 需要让嵌套可变状态在 fan-out 前失败时，可定义自定义 context 容器：
 
@@ -292,16 +384,17 @@ class StrictFlowContext(BaseFlowContext):
     context = ContextVarProvider(dict, copy_policy="strict")
 ```
 
-## retry_decorator
+## `streamlet.retry.retry_decorator`
 
-```python
+```signature
 retry_decorator(
     config: RetryConfig,
     node_name: str | None = None,
-) -> Callable
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]
 ```
 
-独立重试装饰器（`@node` 内部使用 `enable_retry=True` 时自动调用）。支持同步和异步函数。
+模块级重试装饰器，未从 `streamlet` 顶层重导出；`@node` 在
+`enable_retry=True` 时会调用它。支持同步和异步函数。
 
 ## 异常类
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:39a6ddb1cae5934d783481f84a95ddbc24ee6e004f97c2d9ca090c6009254dbe"
+content_hash = "sha256:2121abaea206e858ffae12630ce22e8b322b0c3a3b9c3d29ffd25a6a275b2a2f"
 
 [[metadata.targets]]
 requires_python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ dev = [
     "mypy>=1.13.0",
     "bandit>=1.7.10",
     "pytest-asyncio>=1.1.0",
+    "markdown-it-py>=4.2.0",
+    "typing-extensions>=4.12.0",
 ]
 
 # Ruff configuration

--- a/src/streamlet/context.py
+++ b/src/streamlet/context.py
@@ -101,9 +101,10 @@ class ContextVarProvider(providers.Provider):
 
 
 def capture_context() -> dict[int, Any]:
-    """捕获所有 ContextVarProvider 当前值的快照（fan-out 隔离用）。
+    """捕获所有 ContextVarProvider 当前值的快照。
 
-    仅捕获已初始化的值，不触发 lazy init。
+    用于 fan-out 分支隔离和同步 timeout worker 的上下文传播；仅捕获已初始化的
+    值，不触发 lazy init。
     """
 
     snapshot = {}
@@ -120,6 +121,8 @@ def apply_context(snapshot: dict[int, Any]) -> None:
     同时用于：
     - AsyncExecutor.agather：asyncio Task 间隔离
     - SyncExecutor.gather：线程池 worker 间隔离（线程复用场景）
+    - 同步 timeout：向 func-timeout worker 传播调用线程的上下文
+
     """
 
     for provider in list(_CONTEXTVAR_PROVIDERS):

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -1,0 +1,157 @@
+"""自动验证 Markdown 文档中的 Python 示例。"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import pytest
+from markdown_it import MarkdownIt
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DOC_PATHS = ("README.md", "docs/API参考.md")
+DOC_EXAMPLE_TIMEOUT_SECONDS = 5.0
+PythonExecution = Literal["runnable", "compile-only"]
+
+_DOC_EXAMPLE_RUNNER = """\
+import sys
+
+filename = sys.argv[1]
+line_offset = int(sys.argv[2])
+source = "\\n" * line_offset + sys.stdin.read()
+globals()["__file__"] = filename
+exec(compile(source, filename, "exec", dont_inherit=True), globals())
+"""
+
+
+@dataclass(frozen=True)
+class MarkdownBlock:
+    path: str
+    line: int
+    language: str
+    options: tuple[str, ...]
+    code: str
+
+
+def _load_markdown_blocks(path: str) -> list[MarkdownBlock]:
+    content = (PROJECT_ROOT / path).read_text(encoding="utf-8")
+    blocks: list[MarkdownBlock] = []
+
+    for token in MarkdownIt("commonmark").parse(content):
+        if token.type != "fence":
+            continue
+        info = token.info.split()
+        language = info[0] if info else ""
+        blocks.append(
+            MarkdownBlock(
+                path=path,
+                line=token.map[0] + 1 if token.map else 1,
+                language=language,
+                options=tuple(info[1:]),
+                code=token.content,
+            )
+        )
+
+    return blocks
+
+
+def _load_blocks_by_language(language: str) -> list[MarkdownBlock]:
+    return [
+        block
+        for path in DOC_PATHS
+        for block in _load_markdown_blocks(path)
+        if block.language == language
+    ]
+
+
+def _block_id(block: MarkdownBlock) -> str:
+    return f"{block.path}:{block.line}"
+
+
+def _python_execution(block: MarkdownBlock) -> PythonExecution:
+    if not block.options:
+        return "runnable"
+    if block.options == ("compile-only",):
+        return "compile-only"
+    raise AssertionError(
+        f"Unsupported Python fence options at {_block_id(block)}: {block.options!r}"
+    )
+
+
+def _compile_example(block: MarkdownBlock) -> None:
+    compile(
+        block.code,
+        f"{block.path}:{block.line}",
+        "exec",
+        dont_inherit=True,
+    )
+
+
+def _output_text(output: str | bytes | None) -> str:
+    if isinstance(output, bytes):
+        return output.decode(errors="replace")
+    return output or ""
+
+
+def _example_failure(
+    block: MarkdownBlock,
+    summary: str,
+    *,
+    stdout: str | bytes | None,
+    stderr: str | bytes | None,
+) -> AssertionError:
+    return AssertionError(
+        f"Markdown example at {_block_id(block)} {summary}\n"
+        f"stdout:\n{_output_text(stdout)}\n"
+        f"stderr:\n{_output_text(stderr)}"
+    )
+
+
+def _execute_example(block: MarkdownBlock) -> None:
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-X",
+                "utf8",
+                "-c",
+                _DOC_EXAMPLE_RUNNER,
+                block.path,
+                str(block.line),
+            ],
+            input=block.code,
+            encoding="utf-8",
+            capture_output=True,
+            cwd=PROJECT_ROOT,
+            timeout=DOC_EXAMPLE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise _example_failure(
+            block,
+            f"timed out after {DOC_EXAMPLE_TIMEOUT_SECONDS:g} seconds",
+            stdout=exc.stdout,
+            stderr=exc.stderr,
+        ) from exc
+
+    if result.returncode != 0:
+        raise _example_failure(
+            block,
+            f"failed with exit code {result.returncode}",
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+
+
+PYTHON_BLOCKS = _load_blocks_by_language("python")
+
+
+@pytest.mark.parametrize("block", PYTHON_BLOCKS, ids=_block_id)
+def test_documented_python_block(block: MarkdownBlock) -> None:
+    if _python_execution(block) == "compile-only":
+        _compile_example(block)
+    else:
+        _execute_example(block)

--- a/tests/test_node_decorator.py
+++ b/tests/test_node_decorator.py
@@ -10,11 +10,22 @@ from typing import Annotated
 import pytest
 from dependency_injector.wiring import Provide
 
-from streamlet import BaseFlowContext, Node, NodeTimeoutException, node
+from streamlet import (
+    BaseFlowContext,
+    ContextVarProvider,
+    Node,
+    NodeTimeoutException,
+    node,
+)
 
 
 async def _resolve_value(value: int) -> int:
     return value
+
+
+@node(name="strict_timeout_probe", timeout=1)
+def _strict_timeout_probe() -> None:
+    return None
 
 
 class TestNodeDecoratorCallModes:
@@ -176,6 +187,20 @@ class TestNodeDecoratorTimeout:
         container.wire(modules=[__name__])
 
         assert sync_timeout_di() == "value"
+
+    def test_sync_node_timeout_enforces_strict_context_validation(self):
+        class StrictFlowContext(BaseFlowContext):
+            context = ContextVarProvider(dict, copy_policy="strict")
+
+        container = StrictFlowContext()
+        parent_context = container.context()
+        parent_context["items"] = []
+
+        try:
+            with pytest.raises(ValueError, match="context key 'items'.*nested mutable"):
+                _strict_timeout_probe()
+        finally:
+            parent_context.clear()
 
     @pytest.mark.asyncio
     async def test_async_node_timeout_raises(self):

--- a/tests/typecheck/node_api.py
+++ b/tests/typecheck/node_api.py
@@ -1,0 +1,36 @@
+"""Static type contract for the public ``node`` overloads."""
+
+from collections.abc import Callable
+from typing import Any
+
+from typing_extensions import assert_type
+
+from streamlet import Node, node
+
+
+def increment(value: int) -> int:
+    return value + 1
+
+
+@node
+def bare_decorator(value: int) -> int:
+    return value + 1
+
+
+@node()
+def empty_factory_decorator(value: int) -> int:
+    return value + 1
+
+
+@node(name="configured")
+def configured_decorator(value: int) -> int:
+    return value + 1
+
+
+assert_type(bare_decorator, Node)
+assert_type(empty_factory_decorator, Node)
+assert_type(configured_decorator, Node)
+assert_type(node(increment), Node)
+assert_type(node(increment, name="direct"), Node)
+assert_type(node(), Callable[[Callable[..., Any]], Node])
+assert_type(node(name="factory"), Callable[[Callable[..., Any]], Node])


### PR DESCRIPTION
## 改动

- 自动发现并隔离执行 README 和 API 参考中的 Python 示例，支持 `compile-only` 标记
- 为 `node` overload 增加 mypy 类型契约，并纳入 CI 质量门禁
- 修正文档示例、API 签名和同步 timeout 的 strict context 说明
- 保留 `signature` fence 为展示内容，不增加运行时签名比较逻辑

## 原因

避免文档示例失效和公共类型推断退化，同时让文档准确反映现有运行时行为。

## 影响

生产 API 和执行逻辑不变；新增内容集中在文档、测试和开发依赖。

## 验证

- `pdm run pytest -q`：275 passed
- `pdm run ruff check src/ tests/`
- `pdm run ruff format --check src/ tests/`
- `pdm run mypy src/streamlet/ tests/typecheck/`
- `pdm run bandit -r src/`
- `pdm lock --check`
